### PR TITLE
Injector wont accept sessionholder instance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==6.6
 Flask==0.11.1
 Flask-Injector==0.8.0
 gearman==2.0.2
-injector==0.10.1
+injector==0.11.1
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23

--- a/zsl/resource/model_resource.py
+++ b/zsl/resource/model_resource.py
@@ -24,7 +24,7 @@ from zsl.resource.resource_helper import filter_from_url_arg, apply_related, cre
 from functools import partial
 from zsl.db.helpers import app_models
 from zsl.db.helpers.nested import nested_models, nested_model
-from zsl.service.service import transactional, SqlSesionMixin
+from zsl.service.service import transactional, TransactionalSupport
 from zsl.utils.injection_helper import inject
 from zsl.cache.cache_module import CacheModule
 from zsl.cache.id_helper import IdHelper, create_key_class_prefix
@@ -133,7 +133,7 @@ class ResourceQueryContext(object):
         return self._args.get('filter_by', None)
 
 
-class ModelResource(SqlSesionMixin):
+class ModelResource(TransactionalSupport):
     """
     ModelResource works only for tables with a single-column identifier (key).
 

--- a/zsl/router/task.py
+++ b/zsl/router/task.py
@@ -55,7 +55,7 @@ class TaskRouter(object):
         # finding the path in task packages
         module = None
         for task_package in self.get_task_packages():
-            module_name = "{0}.{1}".format(task_package, ".".join(path[:-1]))
+            module_name = "{0}.{1}".format(task_package, ".".join(path))
 
             try:
                 self._app.logger.debug("Trying to load module with name '%s' and class name '%s'.", module_name,

--- a/zsl/service/service.py
+++ b/zsl/service/service.py
@@ -14,27 +14,6 @@ from zsl.application.initializers.database_initializer import SessionHolder
 from functools import wraps
 
 
-class SqlSesionMixin(object):
-    """
-    Prida podporu pre ``transactional`` dekorator pre metody triedy, 
-    ktora implementuje tento mixin. Samotna session potom bude dostupna
-    cez premennu ``self._orm`` v metode, na ktorej je zaveseny
-    ``transactional`` dekorator
-    
-    Zatial treba inicializovat metodou ``init_sql_session``. 
-    """
-
-    @inject(session_holder=SessionHolder)
-    def init_sql_session(self, session_holder):
-        self._orm = None
-        self._session_holder = session_holder
-        self._in_transaction = False
-        self._transaction_callback = []
-
-    def append_transaction_callback(self, callback):
-        self._transaction_callback.append(callback)
-
-
 class TransactionalSupport(object):
     @inject(session_holder=SessionHolder)
     def __init__(self, session_holder):
@@ -42,6 +21,9 @@ class TransactionalSupport(object):
         self._session_holder = session_holder
         self._in_transaction = False
         self._transaction_callback = []
+
+    def append_transaction_callback(self, callback):
+        self._transaction_callback.append(callback)
 
 
 class Service(TransactionalSupport):
@@ -57,9 +39,6 @@ class Service(TransactionalSupport):
         super(Service, self).__init__()
         self._app = app
         self._engine = engine
-
-    def append_transaction_callback(self, callback):
-        self._transaction_callback.append(callback)
 
 
 def transactional(f):


### PR DESCRIPTION
Surprisingly I could not reproduce the bug, the injector has no problem to register the sessionholder as is an instance of the class it is registering to, I can't remember the exact situation why it did not match before.

I removed `SqlSessionMixin` and used `TransactionalSupport` in model resource. 

I also fixed a bug in router.