### PR TITLE
Reverse order of policy chaining

### DIFF
--- a/tests/resource/resource_guard_test.py
+++ b/tests/resource/resource_guard_test.py
@@ -120,7 +120,7 @@ class TestResourceGuard(TestCase):
     def testApplyTwice(self):
         policy_1 = [1, 2, 3]
         policy_2 = [4, 5, 6]
-        all_policies = policy_1 + policy_2
+        all_policies = policy_2 + policy_1
 
         test_resource_cls = guard(policy_1)(
             guard(policy_2)(

--- a/zsl/resource/guard.py
+++ b/zsl/resource/guard.py
@@ -305,7 +305,7 @@ class guard(object):
 
     def __call__(self, cls):
         if hasattr(cls, '_guard_policies'):
-            self.policies += getattr(cls, '_guard_policies')
+            self.policies = getattr(cls, '_guard_policies') + self.policies
             setattr(cls, '_guard_policies', list(self.policies))
 
             return cls


### PR DESCRIPTION
It is possible to chain policies with applying guard on already guarded resource. This reverse the order, because it is more logical to add new policies before old ones to modify the behavior.
