### PR TITLE
Add type annotations to resource filters

### DIFF
--- a/zsl/__init__.py
+++ b/zsl/__init__.py
@@ -12,7 +12,7 @@ Main service module.
 """
 from __future__ import unicode_literals
 
-__version__ = '0.15.0'
+__version__ = '0.15.2'
 
 from flask import Config
 


### PR DESCRIPTION
Postgres protest if it gets incorrect type in filter clause, this tries to fix it with callbacks which should cast the parameter to correct type.