### PR TITLE
FIX combining policy in resource guard

### DIFF
--- a/tests/resource/resource_guard_test.py
+++ b/tests/resource/resource_guard_test.py
@@ -122,8 +122,8 @@ class TestResourceGuard(TestCase):
         policy_2 = [4, 5, 6]
         all_policies = policy_2 + policy_1
 
-        test_resource_cls = guard(policy_1)(
-            guard(policy_2)(
+        test_resource_cls = guard(policy_2)(
+            guard(policy_1)(
                 self.ToBeSecuredResource
             )
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,4 +44,4 @@ class HttpTestCase(TestCase):
         """
         if hasattr(status, 'value'):  # py2/3
             status = status.value
-        self.assertEquals(status, test_value, msg)
+        self.assertEqual(status, test_value, msg)

--- a/zsl/__init__.py
+++ b/zsl/__init__.py
@@ -12,7 +12,7 @@ Main service module.
 """
 from __future__ import unicode_literals
 
-__version__ = '0.15.2'
+__version__ = '0.15.3'
 
 from flask import Config
 


### PR DESCRIPTION
When guards are applied on top each other, they must combine the policies from the ancestors. This worked although in reversed order, because usually you want to add more specific policies onto more specific resource.

The bug was in guard method wrapping, this is only done once, the first time the guard is applied and it was pointing only to its original policies.
