### PR TITLE
FIX warnings during doc gen and add all modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ Session.vim
 tags
 
 .idea
+/docs/api.rst

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,3 @@
-
 API
 ###
 
@@ -6,9 +5,6 @@ API
    :maxdepth: 2
    :caption: Contents:
 
-.. automodule:: zsl
-   :members:
-   :undoc-members:
 
 .. automodule:: zsl.application
    :members:
@@ -18,11 +14,11 @@ API
    :members:
    :undoc-members:
 
-.. automodule:: zsl.application.containers.container
+.. automodule:: zsl.application.containers.celery_container
    :members:
    :undoc-members:
 
-.. automodule:: zsl.application.containers.celery_container
+.. automodule:: zsl.application.containers.container
    :members:
    :undoc-members:
 
@@ -30,11 +26,11 @@ API
    :members:
    :undoc-members:
 
-.. automodule:: zsl.application.containers.gearman_container
+.. automodule:: zsl.application.containers.web_container
    :members:
    :undoc-members:
 
-.. automodule:: zsl.application.containers.web_container
+.. automodule:: zsl.application.initialization_context
    :members:
    :undoc-members:
 
@@ -58,11 +54,7 @@ API
    :members:
    :undoc-members:
 
-.. automodule:: zsl.application.modules.web.configuration
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.modules.web.web_context_module
+.. automodule:: zsl.application.modules
    :members:
    :undoc-members:
 
@@ -86,15 +78,27 @@ API
    :members:
    :undoc-members:
 
-.. automodule:: zsl.application.modules.gearman_module
-   :members:
-   :undoc-members:
-
 .. automodule:: zsl.application.modules.logger_module
    :members:
    :undoc-members:
 
 .. automodule:: zsl.application.modules.task_router
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.web
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.web.configuration
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.web.web_context_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.service_application
    :members:
    :undoc-members:
 
@@ -138,6 +142,10 @@ API
    :members:
    :undoc-members:
 
+.. automodule:: zsl.db
+   :members:
+   :undoc-members:
+
 .. automodule:: zsl.db.helpers
    :members:
    :undoc-members:
@@ -159,6 +167,10 @@ API
    :undoc-members:
 
 .. automodule:: zsl.db.helpers.sorter
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.model
    :members:
    :undoc-members:
 
@@ -194,19 +206,23 @@ API
    :members:
    :undoc-members:
 
+.. automodule:: zsl.interface.cli
+   :members:
+   :undoc-members:
+
 .. automodule:: zsl.interface.gearman
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.gearman.json_data_encoder
+.. automodule:: zsl.interface.resource
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.gearman.task_filler
+.. automodule:: zsl.interface.task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.gearman.worker
+.. automodule:: zsl.interface.task_queue
    :members:
    :undoc-members:
 
@@ -255,22 +271,6 @@ API
    :undoc-members:
 
 .. automodule:: zsl.interface.webservice.web_application_loader
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.cli
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.resource
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.task
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.task_queue
    :members:
    :undoc-members:
 
@@ -350,14 +350,6 @@ API
    :members:
    :undoc-members:
 
-.. automodule:: zsl.tasks.zsl.schedule_gearman_task
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.tasks.zsl.schedule_kill_worker_task
-   :members:
-   :undoc-members:
-
 .. automodule:: zsl.tasks.zsl.sum_task
    :members:
    :undoc-members:
@@ -370,7 +362,23 @@ API
    :members:
    :undoc-members:
 
+.. automodule:: zsl.unittest
+   :members:
+   :undoc-members:
+
 .. automodule:: zsl.utils
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.utils.cache_helper
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.utils.command_dispatcher
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.utils.date_helper
    :members:
    :undoc-members:
 
@@ -390,31 +398,11 @@ API
    :members:
    :undoc-members:
 
-.. automodule:: zsl.utils.background_task
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.utils.cache_helper
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.utils.command_dispatcher
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.utils.date_helper
-   :members:
-   :undoc-members:
-
 .. automodule:: zsl.utils.email_helper
    :members:
    :undoc-members:
 
 .. automodule:: zsl.utils.file_helper
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.utils.gearman_helper
    :members:
    :undoc-members:
 
@@ -447,6 +435,10 @@ API
    :undoc-members:
 
 .. automodule:: zsl.utils.reflection_helper
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.utils.request_helper
    :members:
    :undoc-members:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,290 @@ API
    :members:
    :undoc-members:
 
+.. automodule:: zsl.application
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.containers
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.containers.container
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.containers.celery_container
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.containers.core_container
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.containers.gearman_container
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.containers.web_container
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.initializers
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.initializers.library_initializer
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.initializers.service_initializer
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.initializers.unittest_initializer
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.initializers.web_initializer
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.web.configuration
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.web.web_context_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.alchemy_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.cache_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.celery_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.cli_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.context_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.gearman_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.logger_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.application.modules.task_router
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.cache
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.cache.cache_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.cache.id_helper
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.cache.redis_cache_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.cache.redis_id_helper
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.configuration
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.contrib
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.contrib.modules
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.contrib.modules.alembic_config
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.contrib.modules.alembic_module
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.helpers
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.helpers.nested
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.helpers.pagination
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.helpers.query_filter
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.helpers.query_helper
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.helpers.sorter
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.model.app_model
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.model.app_model_json_decoder
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.model.app_model_json_encoder
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.model.raw_model
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.db.model.sql_alchemy
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.celery
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.celery.worker
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.gearman
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.gearman.json_data_encoder
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.gearman.task_filler
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.gearman.worker
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.importer
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.performers
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.performers.default
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.performers.method
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.performers.resource
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.performers.task
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.utils
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.utils.error_handler
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.utils.request_data
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.utils.response_headers
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.webservice.web_application_loader
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.cli
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.resource
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.task
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.interface.task_queue
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.resource
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.resource.guard
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.resource.json_server_resource
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.resource.model_resource
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.resource.resource_helper
+   :members:
+   :undoc-members:
+
 .. automodule:: zsl.router
    :members:
    :undoc-members:
@@ -22,119 +306,67 @@ API
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface
+.. automodule:: zsl.service
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice
+.. automodule:: zsl.service.service
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.utils
+.. automodule:: zsl.task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.performers
+.. automodule:: zsl.task.job_context
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.tools
+.. automodule:: zsl.task.task_data
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.gearman
+.. automodule:: zsl.task.task_decorator
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.web_application_loader
+.. automodule:: zsl.task.task_status
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.importer
+.. automodule:: zsl.tasks
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.utils.error_handler
+.. automodule:: zsl.tasks.zsl
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.utils.response_headers
+.. automodule:: zsl.tasks.zsl.db_test_task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.performers.resource
+.. automodule:: zsl.tasks.zsl.kill_worker_task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.performers.method
+.. automodule:: zsl.tasks.zsl.schedule_gearman_task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.performers.default
+.. automodule:: zsl.tasks.zsl.schedule_kill_worker_task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.performers.task
+.. automodule:: zsl.tasks.zsl.sum_task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.webservice.run_webapp
+.. automodule:: zsl.tasks.zsl.test_task
    :members:
    :undoc-members:
 
-.. automodule:: zsl.interface.tools.generate_apiari_doc
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.tools.importer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.tools.js_model_gen
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.gearman.worker
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.gearman.task_filler
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.gearman.json_data_encoder
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.gearman.importer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.gearman.run_worker
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.importer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.cli
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.run_task
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.interface.run_tests
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.resource.resource_helper
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.resource.model_resource
+.. automodule:: zsl.tasks.zsl.version_task
    :members:
    :undoc-members:
 
@@ -143,6 +375,18 @@ API
    :undoc-members:
 
 .. automodule:: zsl.utils.deploy
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.utils.deploy.apiari_doc_generator
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.utils.deploy.integrator
+   :members:
+   :undoc-members:
+
+.. automodule:: zsl.utils.deploy.js_model_generator
    :members:
    :undoc-members:
 
@@ -159,14 +403,6 @@ API
    :undoc-members:
 
 .. automodule:: zsl.utils.date_helper
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.utils.deploy.integrator
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.utils.deploy.js_model_generator
    :members:
    :undoc-members:
 
@@ -238,6 +474,10 @@ API
    :members:
    :undoc-members:
 
+.. automodule:: zsl.utils.testing
+   :members:
+   :undoc-members:
+
 .. automodule:: zsl.utils.type_helper
    :members:
    :undoc-members:
@@ -246,166 +486,14 @@ API
    :members:
    :undoc-members:
 
+.. automodule:: zsl.utils.warnings
+   :members:
+   :undoc-members:
+
 .. automodule:: zsl.utils.xml_helper
    :members:
    :undoc-members:
 
 .. automodule:: zsl.utils.xml_to_json
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.service_application
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.application_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.cache_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.context_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.database_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.library_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.logger_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.service_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application.initializers.unittest_initializer
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.helpers.query_helper
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.helpers.pagination
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.helpers.query_filter
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.helpers.nested
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.helpers.sorter
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.model.app_model_json_decoder
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.model.raw_model
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.model.app_model
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.model.app_model_json_encoder
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.model.sql_alchemy
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.cache.cache_module
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.cache.id_helper
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.cache.redis_cache_module
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.cache.redis_id_helper
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.service.service
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.task.task_decorator
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.task.job_context
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.task.task_status
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.task.task_data
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.resource
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.resource.guard
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.application
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.helpers
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.db.model
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.cache
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.service
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.task
-   :members:
-   :undoc-members:
-
-.. automodule:: zsl.contrib.modules.alembic_module
    :members:
    :undoc-members:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -91,4 +91,4 @@ documentation are in `documentation` extra of `zsl`.
 
     $ pip install sphinx recommonmark sphinx_rtd_theme
     $ cd docs
-    $ make
+    $ make html

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(name='zsl',
           'celery': ['zsl_client'],
           'gearman': ['zsl_client', 'gearman'],
           'alembic': ['alembic'],
-          'documentation': ['sphinx', 'recommonmark', 'sphinx_rtd_theme', 'alembic']
+          'documentation': ['sphinx', 'recommonmark', 'sphinx_rtd_theme',
+                            'alembic']
       },
       classifiers=[
           'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='zsl',
           'celery': ['zsl_client'],
           'gearman': ['zsl_client', 'gearman'],
           'alembic': ['alembic'],
-          'documentation': ['sphinx', 'recommonmark', 'sphinx_rtd_theme']
+          'documentation': ['sphinx', 'recommonmark', 'sphinx_rtd_theme', 'alembic']
       },
       classifiers=[
           'Development Status :: 3 - Alpha',

--- a/zsl/__init__.py
+++ b/zsl/__init__.py
@@ -12,7 +12,7 @@ Main service module.
 """
 from __future__ import unicode_literals
 
-__version__ = '0.15.3'
+__version__ = '0.15.4'
 
 from flask import Config
 

--- a/zsl/db/helpers/sorter.py
+++ b/zsl/db/helpers/sorter.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from builtins import zip
 from builtins import object
 from sqlalchemy import desc, asc
-from string import split
 
 DEFAULT_SORT_ORDER = 'ASC'  # If changed, look at the condition in apply_sorter if self.get_order() == "DESC":.
 
@@ -48,10 +47,10 @@ class Sorter(object):
             mappings = []
 
         if 'sortby' in sorter:
-            self._fields = split(sorter['sortby'], ',')
+            self._fields = sorter['sortby'].split(',')
 
             if 'sort' in sorter:
-                self._orders = split(sorter['sort'], ',')
+                self._orders = sorter['sort'].split(',')
                 if len(self._orders) == 1:
                     self._orders *= len(self._fields)
                 elif len(self._orders) != len(self._fields):

--- a/zsl/resource/model_resource.py
+++ b/zsl/resource/model_resource.py
@@ -83,6 +83,7 @@ def _is_list(list_):
     except TypeError:
         return False
 
+
 class ResourceQueryContext(object):
     """
     The context of the resource query.
@@ -91,12 +92,6 @@ class ResourceQueryContext(object):
      - holds the given filter and splits it to the given field array (parsed from the arguments)
 
     .. automethod:: __init__
-    .. automethod:: get_params 
-    .. automethod:: get_args 
-    .. automethod:: get_data 
-    .. automethod:: get_row_id 
-    .. automethod:: get_related 
-    .. automethod:: get_filter_by 
     """
 
     def __init__(self, params, args, data):
@@ -150,15 +145,10 @@ class ResourceQueryContext(object):
 
 
 class ModelResourceBase(TransactionalSupport):
-    """
-    ModelResource works only for tables with a single-column identifier (key).
+    """ModelResource works only for tables with a single-column identifier
+    (key).
 
     .. automethod:: __init__
-    .. automethod:: _create_context
-    .. automethod:: _create_one
-    .. automethod:: _save_one
-    .. automethod:: _delete_one
-    .. automethod:: _create_delete_one_query
     """
 
     def __init__(self, model_cls=None):
@@ -189,14 +179,24 @@ class ModelResourceBase(TransactionalSupport):
 
 
 class ModelResource(ModelResourceBase):
+    """
+
+    .. automethod:: _create_context
+    .. automethod:: _create_one
+    .. automethod:: _save_one
+    .. automethod:: _delete_one
+    .. automethod:: _create_delete_one_query
+    """
     @staticmethod
     def _create_context(params, args, data):
         # type: (dict, list, dict) -> ResourceQueryContext
         """
-        Creates the resource query context - this an object holding the data alongside the querying of the resource.
-        This object is always present as a parameter for each method during the query and users.py are free to create own
-        properties so that they can optimize and perform the query (so the subsequent methods have an access to the
-        already precomputed data).
+        Creates the resource query context - this an object holding the data
+        alongside the querying of the resource. This object is always present as
+        a parameter for each method during the query and users.py are free to
+        create own properties so that they can optimize and perform the query
+        (so the subsequent methods have an access to the already precomputed
+        data).
         """
         return ResourceQueryContext(params, args, data)
 
@@ -322,7 +322,8 @@ class ModelResource(ModelResourceBase):
         related = ctx.get_related()
         if related is not None:
             q = self.add_related(q, related)
-            return nested_model(self._read_one(q, ctx), create_related_tree(related))
+            return nested_model(self._read_one(q, ctx),
+                                create_related_tree(related))
         else:
             return self._read_one(q, ctx).get_app_model()
 
@@ -368,7 +369,8 @@ class ModelResource(ModelResourceBase):
 
         if related is not None:
             q = self.add_related(q, related)
-            return nested_models(self._read_collection(q, ctx), create_related_tree(related))
+            return nested_models(self._read_collection(q, ctx),
+                                 create_related_tree(related))
         else:
             return app_models(self._read_collection(q, ctx))
 
@@ -423,8 +425,8 @@ class ModelResource(ModelResourceBase):
     # Delete methods
     def _delete_one(self, row_id, ctx):
         """
-        Deletes row by the given id -- `row_id`. The method first created the query using the method
-        :meth:`_create_delete_one_query` and then executes it.
+        Deletes row by the given id -- `row_id`. The method first created the
+        query using the method :meth:`_create_delete_one_query` and then executes it.
 
         :param int row_id: Identifier of the deleted row.
         :param ResourceQueryContext ctx: The context of this delete query.


### PR DESCRIPTION
This fixes all warnings during sphinx documentation generation and adds all modules to the API section except `zsl.tasks.zsl.cors_test_task` which can't be fixed easily. I created a separate task for it.