### PR TITLE
Create camel case string with the first lower char

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ zsl_client
 click>=6.6
 Flask>=0.11
 Flask-Injector==0.8
-injector>=0.11.1
+injector==0.12.1
 redis>=2.10
 requests>=2.7
 SQLAlchemy>=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ zsl_client
 click>=6.6
 Flask>=0.11
 Flask-Injector==0.8
-injector>=0.11.1
+injector==0.12.1
 redis>=2.10
 requests>=2.7
 SQLAlchemy>=1

--- a/tests/utils/test_string_helper.py
+++ b/tests/utils/test_string_helper.py
@@ -1,0 +1,34 @@
+from unittest.case import TestCase
+
+from zsl.utils.string_helper import camelcase_to_underscore, underscore_to_camelcase
+
+
+class InflectionTestCase(TestCase):
+    def testCamelCaseToUnderscore(self):
+        self.assertEquals(
+            "camel_case_to_underscore",
+            camelcase_to_underscore("camelCaseToUnderscore"),
+            "CC to usc conversion"
+        )
+        self.assertEquals(
+            "camel_case_to_underscore",
+            camelcase_to_underscore("CamelCaseToUnderscore"),
+            "CC to usc conversion"
+        )
+
+    def testUnderscoreToCamelCase(self):
+        self.assertEquals(
+            "camelCaseToUnderscore",
+            underscore_to_camelcase("camel_case_to_underscore", False),
+            "CC to usc conversion"
+        )
+        self.assertEquals(
+            "CamelCaseToUnderscore",
+            underscore_to_camelcase("camel_case_to_underscore"),
+            "CC to usc conversion"
+        )
+        self.assertEquals(
+            "CamelCaseToUnderscore",
+            underscore_to_camelcase("camel_case_to_underscore", True),
+            "CC to usc conversion"
+        )

--- a/zsl/utils/string_helper.py
+++ b/zsl/utils/string_helper.py
@@ -16,20 +16,26 @@ _html_tag_re_un = re.compile(
     r'''</?\w+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)/?>''', flags=re.IGNORECASE | re.UNICODE)
 
 
-def underscore_to_camelcase(value):
+def underscore_to_camelcase(value, first_upper=True):
     """Transform string from underscore_string to camelCase.
 
     :param value: string with underscores
+    :param first_upper: the result will have its first character in upper case
     :type value: str
-    :return: string in camelCase
+    :return: string in CamelCase or camelCase according to the first_upper
     :rtype: str
 
     :Example:
         >>> underscore_to_camelcase('camel_case')
+        'CamelCase'
+        >>> underscore_to_camelcase('camel_case', False)
         'camelCase'
     """
     value = str(value)
-    return "".join(x.title() if x else '_' for x in value.split("_"))
+    camelized = "".join(x.title() if x else '_' for x in value.split("_"))
+    if not first_upper:
+        camelized = camelized[0].lower() + camelized[1:]
+    return camelized
 
 
 def camelcase_to_underscore(name):


### PR DESCRIPTION
The camel_case method returned only strings with the first upper char.
A flag was added so that it can control the behaviour.