### PR TITLE
Add full information to pagination

### DIFF
--- a/src/zsl/db/helpers/pagination.py
+++ b/src/zsl/db/helpers/pagination.py
@@ -117,3 +117,5 @@ class PaginationResponse(AppModel):
         max_page_size = pagination.page_size
         self.page_count = (record_count + max_page_size - 1) // max_page_size
         self.page_size = page_size
+        self.max_page_size = max_page_size
+        self.page_no = pagination.page_no


### PR DESCRIPTION
The information about maximal page size and page number was not
outputted. This returns all the information.