### PR TITLE
@secured_task decorator bug

### DIFF
--- a/src/zsl/interface/task.py
+++ b/src/zsl/interface/task.py
@@ -82,7 +82,7 @@ class {name}(parent):
         return self
     """.format(name=name, items=item_definitions, arglist=arglist)
     namespace = {'parent': parent, 'defaults': defaults}
-    exec (class_code, namespace)
+    exec(class_code, namespace)
     result = namespace[name]
     result._source = class_code
     if model_module is None:

--- a/src/zsl/task/task_decorator.py
+++ b/src/zsl/task/task_decorator.py
@@ -333,7 +333,7 @@ def secured_task(f):
             raise SecurityException(
                 task_data.get_data()['security']['hashed_token'])
 
-        task_data.transform_payload(lambda x: x['data'] if 'data' in x else {})
+        task_data.transform_payload(lambda x: x.get('data', {}))
         return f(*args, **kwargs)
 
     return secured_task_decorator

--- a/src/zsl/task/task_decorator.py
+++ b/src/zsl/task/task_decorator.py
@@ -333,7 +333,7 @@ def secured_task(f):
             raise SecurityException(
                 task_data.get_data()['security']['hashed_token'])
 
-        task_data.transform_payload(lambda x: x['data'])
+        task_data.transform_payload(lambda x: x['data'] if 'data' in x else {})
         return f(*args, **kwargs)
 
     return secured_task_decorator

--- a/src/zsl/utils/security_helper.py
+++ b/src/zsl/utils/security_helper.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 
 from builtins import str
 import hashlib
-
 import sys
 
 from zsl import Config, inject

--- a/src/zsl/utils/security_helper.py
+++ b/src/zsl/utils/security_helper.py
@@ -50,8 +50,14 @@ def compute_token(random_token, config):
     :rtype: str
     """
     secure_token = config[TOKEN_SERVICE_SECURITY_CONFIG]
+    msg_to_hash = random_token + secure_token
+
     sha1hash = hashlib.sha1()
-    sha1hash.update(random_token + secure_token)
+    try:
+        sha1hash.update(msg_to_hash.encode('utf-8'))
+    except TypeError:
+        sha1hash.update(msg_to_hash)
+
     return sha1hash.hexdigest().upper()
 
 

--- a/src/zsl/utils/security_helper.py
+++ b/src/zsl/utils/security_helper.py
@@ -76,9 +76,9 @@ def verify_security_data(security):
 def _sha1_py3(msg):
     """Compute sha1 hash of a message.
 
-    :param msg:
+    :param msg: string to hash
     :type msg: str
-    :return:
+    :return: upper case hexdigest representation of a hash
     :type: str
     """
     sha1hash = hashlib.sha1()
@@ -89,9 +89,9 @@ def _sha1_py3(msg):
 def _sha1_py2(msg):
     """Compute sha1 hash of a message.
 
-    :param msg:
+    :param msg: string to hash
     :type msg: str
-    :return:
+    :return: upper case hexdigest representation of a hash
     :type: str
     """
     sha1hash = hashlib.sha1()

--- a/src/zsl/utils/security_helper.py
+++ b/src/zsl/utils/security_helper.py
@@ -10,6 +10,8 @@ from __future__ import unicode_literals
 from builtins import str
 import hashlib
 
+import sys
+
 from zsl import Config, inject
 from zsl.utils.string_helper import generate_random_string
 
@@ -52,13 +54,10 @@ def compute_token(random_token, config):
     secure_token = config[TOKEN_SERVICE_SECURITY_CONFIG]
     msg_to_hash = random_token + secure_token
 
-    sha1hash = hashlib.sha1()
-    try:
-        sha1hash.update(msg_to_hash.encode('utf-8'))
-    except TypeError:
-        sha1hash.update(msg_to_hash)
-
-    return sha1hash.hexdigest().upper()
+    if sys.version_info[0] == 2:
+        return _sha1_py2(msg_to_hash)
+    else:
+        return _sha1_py3(msg_to_hash)
 
 
 def verify_security_data(security):
@@ -72,3 +71,15 @@ def verify_security_data(security):
     random_token = security[TOKEN_RANDOM]
     hashed_token = security[TOKEN_HASHED]
     return str(hashed_token) == str(compute_token(random_token))
+
+
+def _sha1_py3(msg: str) -> str:
+    sha1hash = hashlib.sha1()
+    sha1hash.update(msg.encode('utf-8'))
+    return sha1hash.hexdigest().upper()
+
+
+def _sha1_py2(msg: str) -> str:
+    sha1hash = hashlib.sha1()
+    sha1hash.update(msg)
+    return sha1hash.hexdigest().upper()

--- a/src/zsl/utils/security_helper.py
+++ b/src/zsl/utils/security_helper.py
@@ -73,13 +73,27 @@ def verify_security_data(security):
     return str(hashed_token) == str(compute_token(random_token))
 
 
-def _sha1_py3(msg: str) -> str:
+def _sha1_py3(msg):
+    """Compute sha1 hash of a message.
+
+    :param msg:
+    :type msg: str
+    :return:
+    :type: str
+    """
     sha1hash = hashlib.sha1()
     sha1hash.update(msg.encode('utf-8'))
     return sha1hash.hexdigest().upper()
 
 
-def _sha1_py2(msg: str) -> str:
+def _sha1_py2(msg):
+    """Compute sha1 hash of a message.
+
+    :param msg:
+    :type msg: str
+    :return:
+    :type: str
+    """
     sha1hash = hashlib.sha1()
     sha1hash.update(msg)
     return sha1hash.hexdigest().upper()

--- a/tests/task_decorators/secured_task_test.py
+++ b/tests/task_decorators/secured_task_test.py
@@ -32,8 +32,10 @@ class SecuredTaskTestCase(ZslTestCase, HTTPTestCase, TestCase):
     })
 
     ZSL_TEST_CONFIGURATION = ZslTestConfiguration(
-        app_name='SecuredTaskTestCase', container=WebContainer,
-        config_object=CONFIG)
+        app_name='SecuredTaskTestCase',
+        container=WebContainer,
+        config_object=CONFIG
+    )
 
     def testSecuredTaskWithCorrectSecurityToken(self):
         client = self.getHTTPClient()

--- a/tests/task_decorators/secured_task_test.py
+++ b/tests/task_decorators/secured_task_test.py
@@ -1,17 +1,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import http.client
 from builtins import *
+import http.client
 from unittest.case import TestCase
 
 from zsl.application.containers.web_container import WebContainer
 from zsl.application.modules.web.cors import CORSConfiguration
 from zsl.router.task import TaskConfiguration
-from zsl.task.task_decorator import secured_task, json_input
+from zsl.task.task_decorator import json_input, secured_task
 from zsl.testing.db import IN_MEMORY_DB_SETTINGS
 from zsl.testing.http import HTTPTestCase
 from zsl.testing.zsl import ZslTestCase, ZslTestConfiguration
-from zsl.utils.security_helper import TOKEN_SERVICE_SECURITY_CONFIG, TOKEN_RANDOM, TOKEN_HASHED, compute_token
+from zsl.utils.security_helper import TOKEN_HASHED, TOKEN_RANDOM, TOKEN_SERVICE_SECURITY_CONFIG, compute_token
 
 
 class SecuredTask(object):

--- a/tests/task_decorators/secured_task_test.py
+++ b/tests/task_decorators/secured_task_test.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import http.client
+from builtins import *
+from unittest.case import TestCase
+
+from zsl.application.containers.web_container import WebContainer
+from zsl.application.modules.web.cors import CORSConfiguration
+from zsl.router.task import TaskConfiguration
+from zsl.task.task_decorator import secured_task, json_input
+from zsl.testing.db import IN_MEMORY_DB_SETTINGS
+from zsl.testing.http import HTTPTestCase
+from zsl.testing.zsl import ZslTestCase, ZslTestConfiguration
+from zsl.utils.security_helper import TOKEN_SERVICE_SECURITY_CONFIG, TOKEN_RANDOM, TOKEN_HASHED, compute_token
+
+
+class SecuredTask(object):
+
+    @json_input
+    @secured_task
+    def perform(self, data):
+        return "ok"
+
+
+class SecuredTaskTestCase(ZslTestCase, HTTPTestCase, TestCase):
+    CONFIG = IN_MEMORY_DB_SETTINGS.copy()
+    CONFIG.update({
+        'CORS': CORSConfiguration('origin'),
+        'TASKS': TaskConfiguration().create_namespace('test').add_routes(
+            {'secured_task': SecuredTask}).get_configuration(),
+        TOKEN_SERVICE_SECURITY_CONFIG: 'ahoj'
+    })
+
+    ZSL_TEST_CONFIGURATION = ZslTestConfiguration(
+        app_name='SecuredTaskTestCase', container=WebContainer,
+        config_object=CONFIG)
+
+    def testSecuredTaskWithCorrectSecurityToken(self):
+        client = self.getHTTPClient()
+        random_token = '1'
+
+        response = self.requestTask(client, 'test/secured_task', {
+            'security': {
+                TOKEN_RANDOM: random_token,
+                TOKEN_HASHED: compute_token(random_token)
+            },
+        })
+
+        self.assertHTTPStatus(http.client.OK, response.status_code, 'Http status should be 200')
+
+    def testSecuredTaskWithIncorrectSecurityToken(self):
+        client = self.getHTTPClient()
+        random_token = '1'
+
+        response = self.requestTask(client, 'test/secured_task', {
+            'security': {
+                TOKEN_RANDOM: random_token,
+                TOKEN_HASHED: 'incorrect hash'
+            },
+        })
+
+        self.assertHTTPStatus(http.client.INTERNAL_SERVER_ERROR, response.status_code, 'Http status should be 500')


### PR DESCRIPTION
resolves issue #101 

in python2.7 the update() method of hash object (obtained by
hashlib.sha1() call) takes string as a parameter. However in python3.6
it takes bytes