### PR TITLE
90 celery worker ignore arguments given on start

### DIFF
--- a/src/zsl/application/modules/gearman_module.py
+++ b/src/zsl/application/modules/gearman_module.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import click
 from injector import ClassProvider, Module, singleton
 
-from zsl import Zsl, inject
+from zsl import inject
 from zsl.application.modules.cli_module import ZslCli
 from zsl.interface.gearman.task_filler import exec_task_filler
 from zsl.interface.gearman.worker import GearmanTaskQueueWorker
@@ -20,7 +20,7 @@ class GearmanCli(object):
     def __init__(self, zsl_cli):
         # type: (ZslCli)->GearmanCli
 
-        @zsl_cli.cli.group("Gearman related tasks.")
+        @zsl_cli.cli.group(help="Gearman related tasks.")
         def gearman():
             pass
 
@@ -29,7 +29,7 @@ class GearmanCli(object):
             # type: () -> None
             run_worker()
 
-        @gearman.command()
+        @gearman.command(help="send task to queue")
         @click.argument('task_path', metavar='task')
         @click.argument('data', default=None, required=False)
         def task_filler(task_path, data):

--- a/src/zsl/interface/celery/worker.py
+++ b/src/zsl/interface/celery/worker.py
@@ -70,7 +70,7 @@ class CeleryTaskQueueMainWorker(CeleryTaskQueueWorkerBase):
         self._app.logger.info("Stopping Celery worker on demand - quitting.")
         self.celery_worker.stop()
 
-    def run(self, argv, *args, **kwargs):
+    def run(self, argv):
         self._app.logger.info("Running the worker.")
         self.celery_worker = self.celery_app.worker_main((sys.argv[0],) + argv)
 

--- a/src/zsl/interface/task_queue.py
+++ b/src/zsl/interface/task_queue.py
@@ -123,10 +123,16 @@ class TaskQueueWorker(with_metaclass(abc.ABCMeta, object)):
 
 
 @inject(worker=TaskQueueWorker)
-def run_worker(self, worker, *args, **kwargs):
-    # type: (TaskQueueWorker, *Any, **Any)->None
+def _get_worker(worker):
+    # type: (TaskQueueWorker) -> TaskQueueWorker
+    return worker
+
+
+def run_worker(*args, **kwargs):
+    # type: (*Any, **Any)->None
     """Run the app as a task queue worker.
 
     The worker instance is given as a DI module.
     """
-    worker.run((), *args, **kwargs)
+    worker = _get_worker()
+    worker.run(*args, **kwargs)

--- a/tests/interface/worker/run_dummy_worker_with_params_test.py
+++ b/tests/interface/worker/run_dummy_worker_with_params_test.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+
+from injector import Module, singleton
+
+from zsl import inject
+from zsl.application.containers.core_container import CoreContainer
+from zsl.interface.task_queue import TaskQueueWorker, run_worker
+from zsl.testing.db import IN_MEMORY_DB_SETTINGS
+from zsl.testing.zsl import ZslTestCase, ZslTestConfiguration
+
+
+class DummyWorker(TaskQueueWorker):
+
+    def __init__(self):
+        super(DummyWorker, self).__init__()
+        self.run_count = 0
+        self.last_param_1 = None
+        self.last_param_2 = None
+
+    def run(self, param_1, param_2='ahoj'):
+        self.run_count += 1
+        self.last_param_1 = param_1
+        self.last_param_2 = param_2
+
+    def stop_worker(self):
+        pass
+
+
+class DummyWorkerTaskQueueModule(Module):
+
+    def configure(self, binder):
+        worker = DummyWorker()
+        binder.bind(TaskQueueWorker, to=worker, scope=singleton)
+
+
+class DummyWorkerContainer(CoreContainer):
+    dummy_worker = DummyWorkerTaskQueueModule
+
+
+class RunDummyWorkerWithParamsTestCase(ZslTestCase, TestCase):
+    CONFIG = IN_MEMORY_DB_SETTINGS.copy()
+    ZSL_TEST_CONFIGURATION = ZslTestConfiguration(
+        app_name='RunDummyWorkerWithParamsTestCase', container=DummyWorkerContainer,
+        config_object=CONFIG)
+
+    _PARAM_1_TEST_VALUE = 1
+    _PARAM_2_TEST_VALUE = 'Dont forget to read some good books!'
+
+    @inject(worker=TaskQueueWorker)
+    def testWorkerRunCountAndRunParams(self, worker):
+        self.assertEqual(worker.run_count, 0, "worker.run() shouldn't be called yet.")
+
+        run_worker(self._PARAM_1_TEST_VALUE, param_2=self._PARAM_2_TEST_VALUE)
+
+        self.assertEqual(worker.run_count, 1, "worker.run() should be called exactly once.")
+        self.assertEqual(worker.last_param_1, self._PARAM_1_TEST_VALUE, "worker.run() has obtained incorrect parameter 'param_1'.")
+        self.assertEqual(worker.last_param_2, self._PARAM_2_TEST_VALUE, "worker.run() has obtained incorrect parameter 'param_2'.")

--- a/tests/interface/worker/run_dummy_worker_without_params_test.py
+++ b/tests/interface/worker/run_dummy_worker_without_params_test.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+
+from injector import Module, singleton
+
+from zsl import inject
+from zsl.application.containers.core_container import CoreContainer
+from zsl.interface.task_queue import TaskQueueWorker, run_worker
+from zsl.testing.db import IN_MEMORY_DB_SETTINGS
+from zsl.testing.zsl import ZslTestCase, ZslTestConfiguration
+
+
+class DummyWorker(TaskQueueWorker):
+
+    def __init__(self):
+        super(DummyWorker, self).__init__()
+        self.run_count = 0
+
+    def run(self):
+        self.run_count += 1
+
+    def stop_worker(self):
+        pass
+
+
+class DummyWorkerTaskQueueModule(Module):
+
+    def configure(self, binder):
+        worker = DummyWorker()
+        binder.bind(TaskQueueWorker, to=worker, scope=singleton)
+
+
+class DummyWorkerContainer(CoreContainer):
+    dummy_worker = DummyWorkerTaskQueueModule
+
+
+class RunDummyWorkerWithoutParamsTestCase(ZslTestCase, TestCase):
+    CONFIG = IN_MEMORY_DB_SETTINGS.copy()
+    ZSL_TEST_CONFIGURATION = ZslTestConfiguration(
+        app_name='RunDummyWorkerWithoutParamsTestCase', container=DummyWorkerContainer,
+        config_object=CONFIG)
+
+    @inject(worker=TaskQueueWorker)
+    def testWorkerRunCount(self, worker):
+        self.assertEqual(worker.run_count, 0, "worker.run() shouldn't be called yet.")
+
+        run_worker()
+
+        self.assertEqual(worker.run_count, 1, "worker.run() should be called exactly once.")


### PR DESCRIPTION
- resolves the issue #90 

Description of changes:
- fixing run_worker() function
- creating unit tests for run_worker() function
- fixing GearmanCli class - incorrect creation of click command group
- simplyfying CeleryTaskQueueMainWorker.run() method signature
