### PR TITLE
updating Flask version specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ enum34
 future
 zsl_client
 click>=6.6
-Flask==0.12.3
+Flask==1.0.*
 injector==0.12.1
 redis>=2.10
 requests>=2.7

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 _is_py3 = sys.version_info > (3, 0)
 
 requirements = [
-    'flask>=0.12.3',
+    'flask==1.0.*',
     'future',
     'injector==0.12.1',
     'requests>=2.7',


### PR DESCRIPTION
1) the reason why this error was not discovered by zsl unit tests is that `tox` was running the unittests within old environment with older Flask version (<1.0). When I ran the tests with `tox -r` (`-r` is flag for recreating environment), the unit tests started failing.

2) The reported error is caused by method `LoggerModule._recreate_app_logger()` where the access to non-existing `Flask.logger_name` attribute is made (the attribute was removed in Flask 1.0)

3) Probably the routing is also not working. It seems that all unit tests that make requests to zsl app fail because the zsl app response to request is always HTTP 400 or HTTP 404