### PR TITLE
Feature/filter by multiple values

### DIFF
--- a/src/zsl/resource/resource_helper.py
+++ b/src/zsl/resource/resource_helper.py
@@ -73,29 +73,29 @@ def filter_from_url_arg(model_cls, query, arg, query_operator=and_,
     return query.join(*joins).filter(query_operator(*exprs))
 
 
-def _join_equal_columns_to_or(exprs):
-    left_sides = list(map(lambda expr: expr.get_children()[0], exprs))
-    if len(left_sides) == len(set(left_sides)):
-        return exprs
+def _join_equal_columns_to_or(filter_expressions):
+    columns = list(map(lambda expr: expr.get_children()[0], filter_expressions))
+    if len(columns) == len(set(columns)):
+        return filter_expressions
 
-    joined_exprs = {}
-    for expr in exprs:
-        left_side = expr.get_children()[0]
-        if left_side in joined_exprs:
-            joined_exprs[left_side].append(expr)
+    joined_expressions = {}
+    for filter_expression in filter_expressions:
+        column = filter_expression.get_children()[0]
+        if column in joined_expressions:
+            joined_expressions[column].append(filter_expression)
         else:
-            joined_exprs[left_side] = [expr]
+            joined_expressions[column] = [filter_expression]
 
-    new_exprs = []
-    for _, expressions in joined_exprs.items():
+    final_expressions = []
+    for _, expressions in joined_expressions.items():
         if len(expressions) == 0:
             continue
         elif len(expressions) == 1:
-            new_exprs.append(expressions[0])
+            final_expressions.append(expressions[0])
         else:
-            new_exprs.append(or_(*expressions))
+            final_expressions.append(or_(*expressions))
 
-    return new_exprs
+    return final_expressions
 
 
 operator_to_method = {

--- a/src/zsl/utils/request_helper.py
+++ b/src/zsl/utils/request_helper.py
@@ -11,12 +11,23 @@ from future.utils import viewitems
 
 
 def args_to_dict(args):
-    """Converts request arguments to a simple dictionary. Uses only the first
-    value.
+    """Converts request arguments to a simple dictionary. If an argument
+    appears multiple times, the resulting dictionary will contain list
+    of all of its values.
 
     :param args: flask's request args object
     :type args: request.args
     :return: a simple dict from args
     :rtype: dict
     """
-    return args.to_dict(flat=True)
+    args_dict = {}
+    for param_name, param_value in args.items(multi=True):
+        if param_name not in args_dict:
+            args_dict[param_name] = param_value
+        elif not isinstance(args_dict[param_name], list):
+            current_value = args_dict[param_name]
+            args_dict[param_name] = [current_value, param_value]
+        else:
+            args_dict[param_name].append(param_value)
+
+    return args_dict

--- a/tests/resource/resource_helper_test.py
+++ b/tests/resource/resource_helper_test.py
@@ -1,0 +1,54 @@
+from unittest.case import TestCase
+
+from sqlalchemy.orm import Session
+
+from tests.resource.resource_test_helper import create_resource_test_data, UserModel
+from zsl import Zsl
+from zsl.resource.resource_helper import filter_from_url_arg
+from zsl.testing.db import IN_MEMORY_DB_SETTINGS
+
+
+class ModelResourceTest(TestCase):
+
+    def setUp(self):
+        Zsl(__name__, config_object=IN_MEMORY_DB_SETTINGS)
+        create_resource_test_data()
+
+    def testFilterEmpty(self):
+        query = Session().query(UserModel)
+        query = filter_from_url_arg(UserModel, query, "")
+
+        contains_where_clause = 'where' in str(query).lower()
+
+        self.assertFalse(contains_where_clause, "The query should not contain any filter")
+
+    def testFilterMultipleArgs(self):
+        query = Session().query(UserModel)
+        filter_by = 'id==1,id==2,id==5'
+
+        query = filter_from_url_arg(UserModel, query, filter_by)
+
+        # the where clause should be: 'id == 1 or id == 2 or id == 5'
+        where_clause = str(query).lower().split('where')[1]
+        filter_clauses = where_clause.split('or')
+
+        self.assertEqual(len(filter_clauses), 3, "There should be 3 filter clauses separated by OR")
+
+    def testFilterCombinationsOfArgs(self):
+        query = Session().query(UserModel)
+        filter_by = 'id==1,id==2,name==julius,id==5'
+
+        query = filter_from_url_arg(UserModel, query, filter_by)
+        print(str(query))
+
+        # the where clause should be: '(id == 1 or id == 2 or id == 5) and name == julius'
+        where_clause = str(query).lower().split('where')[1]
+        filter_conjunctions = where_clause.split('and')
+        self.assertEqual(len(filter_conjunctions), 2, "There should be conjunction of two clauses in the query")
+
+        first_clause = filter_conjunctions[0].split('or')
+        second_clause = filter_conjunctions[1].split('or')
+
+        self.assertTrue(len(first_clause) == 3 or len(second_clause) == 3,
+                        "One of the clauses should have 3 conditions")
+        self.assertTrue(len(first_clause) == 1 or len(second_clause) == 1, "One of the clauses should have 1 condition")

--- a/tests/utils/request_helper_test.py
+++ b/tests/utils/request_helper_test.py
@@ -1,0 +1,37 @@
+__author__ = 'julius'
+
+from unittest.case import TestCase
+
+from werkzeug.datastructures import ImmutableMultiDict
+
+from zsl.utils.request_helper import args_to_dict
+
+
+class InflectionTestCase(TestCase):
+
+    def test_empty(self):
+        args = ImmutableMultiDict([])
+        args_dict = args_to_dict(args)
+        self.assertEqual(args_dict, {}, "Arguments dictionary should be empty for empty arguments object")
+
+    def test_one_param(self):
+        args = ImmutableMultiDict([('a', 1)])
+        args_dict = args_to_dict(args)
+        self.assertEqual(args_dict, {'a': 1}, "Arguments dictionary should contain the one argument")
+
+    def test_more_params(self):
+        args = ImmutableMultiDict([('a', 1), ('b', 2), ('c', 42)])
+        args_dict = args_to_dict(args)
+        self.assertEqual(args_dict, {'a': 1, 'b': 2, 'c': 42}, "Arguments dictionary should contain the same "
+                                                               "parameters as the arguments object")
+
+    def test_multi_param(self):
+        args = ImmutableMultiDict([('a', 2), ('a', 4), ('a', 8)])
+        args_dict = args_to_dict(args)
+        self.assertEqual(args_dict, {'a': [2, 4, 8]}, "The param should be list of all of its values")
+
+    def test_multi_params_with_other_params(self):
+        args = ImmutableMultiDict([('a', 3), ('b', 'PWR UP'), ('a', 9), ('a', 27)])
+        args_dict = args_to_dict(args)
+        self.assertEqual(args_dict, {'a': [3, 9, 27], 'b': 'PWR UP'}, "Arguments dictionary should contain the same "
+                                                                      "parameters as the arguments object")


### PR DESCRIPTION
1. If there is some better way to test the correctness `where` clauses in the sqlalchemy queries than looking at the query string I'll be happy to reimplement them

2. why does `JsonServerResource._create_filter_by()` uses `request.args` to look at the arguments and not at `args` param from `_transform_list_args` like all the other functions?